### PR TITLE
Use SchemaBuilderInterface in GraphQlExportCommand

### DIFF
--- a/src/Bridge/Symfony/Bundle/Command/GraphQlExportCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/GraphQlExportCommand.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Core\Bridge\Symfony\Bundle\Command;
 
-use ApiPlatform\Core\GraphQl\Type\SchemaBuilder;
+use ApiPlatform\Core\GraphQl\Type\SchemaBuilderInterface;
 use GraphQL\Utils\SchemaPrinter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -34,7 +34,7 @@ class GraphQlExportCommand extends Command
 
     private $schemaBuilder;
 
-    public function __construct(SchemaBuilder $schemaBuilder)
+    public function __construct(SchemaBuilderInterface $schemaBuilder)
     {
         $this->schemaBuilder = $schemaBuilder;
 


### PR DESCRIPTION
Q | A
-- | --
Bug fix? | yes
New feature? | no
BC breaks? | no
Deprecations? | no
Tickets | 
License | MIT
Doc PR

The reason for this change is to allow decorating the SchemaBuilder